### PR TITLE
Update config/database.php

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -38,7 +38,7 @@ return [
             /*
              * These settings are set by the installer and are stored in storage/app/database.ini
              */
-            //'host'      => env('DB_HOST', '127.0.0.1'),
+            //'host'      => env('DB_HOST', 'localhost'),
             //'database'  => env('DB_DATABASE', 'contentify'),
             //'username'  => env('DB_USERNAME', 'root'),
             //'password'  => env('DB_PASSWORD', ''),


### PR DESCRIPTION
Updated config/database.php
fixing most of the errors occurs on Ubuntu 16.04 - Debian 8 - Centos and cPanel as well.

Fixes issues like : Access denied for user 'db'@'localhost' (SQL: SHOW TABLES LIKE "migrations") etc